### PR TITLE
Fixed Bug. Vulnerability in package npm

### DIFF
--- a/beatrizsmerino/class-18/new-york-times-best-sellers/package-lock.json
+++ b/beatrizsmerino/class-18/new-york-times-best-sellers/package-lock.json
@@ -139,18 +139,18 @@
 			"dev": true
 		},
 		"minimist": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 			"dev": true
 		},
 		"mkdirp": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 			"dev": true,
 			"requires": {
-				"minimist": "0.0.8"
+				"minimist": "^1.2.5"
 			}
 		},
 		"requizzle": {


### PR DESCRIPTION
1 minimist vulnerability found in .../new-york-times-best-sellers/package-lock.json

Upgraded minimalist to version 1.2.5 with the next commands:
	`npm install`
	`npm audit fix`

![Captura de pantalla 2020-04-16 a las 23 30 43](https://user-images.githubusercontent.com/14045148/79509711-53c47b00-803c-11ea-84e5-64e24c94eb30.png)